### PR TITLE
Adjust to libsyntax API change

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ fn interpolate_idents<'a>(cx: &'a mut ExtCtxt,
                                 Some(ref mut s) => { s.hi = span.hi; },
                                 None => { new_span = Some(span.clone()); },
                             }
-                            new_ident.push_str(ident.name.as_str());
+                            new_ident.push_str(&ident.name.as_str());
                         },
                         _ => return None,
                     }


### PR DESCRIPTION
This fixes a compiler error on current nightly:

```
src/lib.rs:36:48: 36:67 error: mismatched types:
 expected `&str`,
    found `syntax::parse::token::InternedString`
(expected &-ptr,
    found struct `syntax::parse::token::InternedString`) [E0308]
src/lib.rs:36                             new_ident.push_str(ident.name.as_str());
                                                             ^~~~~~~~~~~~~~~~~~~
```
