### PR TITLE
Update for nightly 2/22/2016.

### DIFF
--- a/src/parser_any_macro.rs
+++ b/src/parser_any_macro.rs
@@ -77,7 +77,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
     }
 
     fn make_impl_items(self: Box<ParserAnyMacro<'a>>)
-                       -> Option<SmallVector<P<ast::ImplItem>>> {
+                       -> Option<SmallVector<ast::ImplItem>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();
@@ -91,7 +91,7 @@ impl<'a> MacResult for ParserAnyMacro<'a> {
     }
 
     fn make_stmts(self: Box<ParserAnyMacro<'a>>)
-                 -> Option<SmallVector<P<ast::Stmt>>> {
+                 -> Option<SmallVector<ast::Stmt>> {
         let mut ret = SmallVector::zero();
         loop {
             let mut parser = self.parser.borrow_mut();


### PR DESCRIPTION
Don't merge this just yet, I'm getting some internal compiler errors when using this and I'm not sure why. I'll keep investigating.

Backtrace:

```
#0  0x00007ffff752ddd2 in sys_common::unwind::begin_unwind_inner::h78583c314295e3926mt () from /home/vagrant/.multirust/toolchains/nightly/lib/libstd-fd663c41.so
#1  0x00007ffff33195d0 in sys_common::unwind::begin_unwind::h6390803597107181457
    ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#2  0x00007ffff3320c80 in errors::DiagnosticBuilder$LT$$u27$a$GT$.Drop::drop::h6b159658d28aa5413Bd ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#3  0x00007fffec21398d in syntax..errors..DiagnosticBuilder::drop.12089::ha92d09a84e6df294 ()
   from /vagrant/target/debug/deps/libinterpolate_idents-a45000580ffc7eaf.so
#4  0x00007fffec2138a2 in interpolate_idents::result::unwrap_failed<syntax::errors::DiagnosticBuilder> (msg="called `Result::unwrap()` on an `Err` value",
    error=DiagnosticBuilder = {...}) at ../src/libcore/result.rs:745
#5  0x00007fffec21501c in interpolate_idents::result::Result<T, E>::unwrap (
    self=Err = {...}) at ../src/libcore/result.rs:687
#6  0x00007fffec1c015a in interpolate_idents::parser_any_macro::ParserAnyMacro<'a>.MacResult::make_items (self=0x7fffedd42800)
    at /home/vagrant/.multirust/toolchains/nightly/cargo/git/checkouts/interpolate_idents-903dd87e7c96fd66/master/src/parser_any_macro.rs:72
#7  0x00007ffff35d4ab4 in ext::expand::expand_item_mac::had0dccc4ab3e2c72KE9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#8  0x00007ffff35c24d4 in ext::expand::expand_annotatable::hf93d10bcf6dc7c51L89
    ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#9  0x00007ffff35bf699 in ext::expand::expand_item::hc94e1847f5d57dd3YB9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#10 0x00007ffff35ce092 in ext::expand::MacroExpander$LT$$u27$a$C$$u20$$u27$b$GT$.Folder::fold_item::h24880465a24581c5Vqa ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#11 0x00007ffff35d618d in ops::impls::_$RF$$u27$a$u20$mut$u20$F.FnOnce$LT$A$GT$::call_once::h1218104079685283767 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#12 0x00007ffff35d5df6 in iter::FlatMap$LT$I$C$$u20$U$C$$u20$F$GT$.Iterator::next::h14503001973133149142 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#13 0x00007ffff35d58a8 in util::small_vector::SmallVector$LT$T$GT$.FromIterator$LT$T$GT$::from_iter::h11802914642045737515 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#14 0x00007ffff35d4c1e in ext::expand::expand_item_mac::had0dccc4ab3e2c72KE9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#15 0x00007ffff35c24d4 in ext::expand::expand_annotatable::hf93d10bcf6dc7c51L89
    ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#16 0x00007ffff35bf699 in ext::expand::expand_item::hc94e1847f5d57dd3YB9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#17 0x00007ffff35ce092 in ext::expand::MacroExpander$LT$$u27$a$C$$u20$$u27$b$GT$.Folder::fold_item::h24880465a24581c5Vqa ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#18 0x00007ffff35cddd4 in fold::noop_fold_mod::h10906896745153660339 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#19 0x00007ffff35c7014 in ext::expand::expand_item_kind::h5159d23e07fab7bazC9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#20 0x00007ffff3603aff in fold::noop_fold_item_simple::h5812836082933725839 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#21 0x00007ffff3603671 in fold::noop_fold_item::h219719951470748899 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#22 0x00007ffff35c3da1 in ext::expand::expand_annotatable::hf93d10bcf6dc7c51L89
    ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#23 0x00007ffff35bf699 in ext::expand::expand_item::hc94e1847f5d57dd3YB9 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#24 0x00007ffff3611086 in ext::expand::expand_crate::h0ae6334146a90911Qwa ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libsyntax-fd663c41.so
#25 0x00007ffff7ab7184 in driver::phase_2_configure_and_expand::_$u7b$$u7b$closure$u7d$$u7d$::closure.33825 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#26 0x00007ffff7a65aaf in driver::phase_2_configure_and_expand::h3ea9df8b9c1b4fe0ZAa ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#27 0x00007ffff7a476c2 in driver::compile_input::h9417f7071f41b0b1Bca ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#28 0x00007ffff7a39908 in run_compiler::h1d04446f72d95b52HOc ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#29 0x00007ffff7a370b2 in sys_common::unwind::try::try_fn::h2224149726337910613
    ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#30 0x00007ffff7559d9c in __rust_try ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libstd-fd663c41.so
#31 0x00007ffff755234e in sys_common::unwind::inner_try::hdfdf33e7068c9cb28jt ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/libstd-fd663c41.so
#32 0x00007ffff7a37901 in boxed::F.FnBox$LT$A$GT$::call_box::h8331008289514682961 ()
   from /home/vagrant/.multirust/toolchains/nightly/lib/librustc_driver-fd663c41.so
#33 0x00007ffff7563c7a in sys::thread::Thread::new::thread_start::h1272204999bddc95vby () from /home/vagrant/.multirust/toolchains/nightly/lib/libstd-fd663c41.so
#34 0x00007fffefcce182 in start_thread (arg=0x7fffedbff700)
    at pthread_create.c:312
#35 0x00007ffff71d147d in clone ()
    at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111
```
