### PR TITLE
Try to make the error reporting better

### DIFF
--- a/src/parser_any_macro.rs
+++ b/src/parser_any_macro.rs
@@ -58,18 +58,18 @@ impl<'a> ParserAnyMacro<'a> {
 
 impl<'a> MacResult for ParserAnyMacro<'a> {
     fn make_expr(self: Box<ParserAnyMacro<'a>>) -> Option<P<ast::Expr>> {
-        let ret = self.parser.borrow_mut().parse_expr().unwrap();
+        let ret = panictry!(self.parser.borrow_mut().parse_expr());
         self.ensure_complete_parse(true);
         Some(ret)
     }
     fn make_pat(self: Box<ParserAnyMacro<'a>>) -> Option<P<ast::Pat>> {
-        let ret = self.parser.borrow_mut().parse_pat().unwrap();
+        let ret = panictry!(self.parser.borrow_mut().parse_pat());
         self.ensure_complete_parse(false);
         Some(ret)
     }
     fn make_items(self: Box<ParserAnyMacro<'a>>) -> Option<SmallVector<P<ast::Item>>> {
         let mut ret = SmallVector::zero();
-        while let Some(item) = self.parser.borrow_mut().parse_item().unwrap() {
+        while let Some(item) = panictry!(self.parser.borrow_mut().parse_item()) {
             ret.push(item);
         }
         self.ensure_complete_parse(false);

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,10 +24,13 @@ fn test_macro() {
 
 macro_rules! define_brackets {
     () => ( interpolate_idents! {
-        fn brackets() -> Vec<i32> {
+        fn brackets(data: &[i32; 1]) -> Vec<i32> {
             let mut b: Vec<i32> = vec![];
             let c: Vec<i32> = vec![1, 2, 3];
+            let d: Vec<i32> = vec![1; 25];
             b.push(c[1]);
+            b.push(d[1]);
+            b.push(data[0]);
             b
         }
     } )
@@ -37,5 +40,6 @@ define_brackets!();
 
 #[test]
 fn test_brackets() {
-    assert_eq!(brackets(), vec![2]);
+    let data = [1; 1];
+    assert_eq!(brackets(&data), vec![2, 1, 1]);
 }


### PR DESCRIPTION
Using unwrap() makes the actual parsing error not reported properly confusing the user a lot.

I extended the test coverage a little while at it.
