### PR TITLE
Fix for latest nightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,9 +62,7 @@ fn interpolate_idents<'a>(cx: &'a mut ExtCtxt,
                         None => {
                             TokenTree::Delimited(s.clone(), Rc::new(syntax::tokenstream::Delimited {
                                 delim: d.delim,
-                                open_span: d.open_span,
                                 tts: map_tts(&*d.tts),
-                                close_span: d.close_span,
                             }))
                         },
                     }


### PR DESCRIPTION
Looks like they got rid of these fields - https://github.com/rust-lang/rust/blob/master/src/libsyntax/tokenstream.rs#L45.