### PR TITLE
Fixes compile error on FatalError struct

### DIFF
--- a/src/parser_any_macro.rs
+++ b/src/parser_any_macro.rs
@@ -18,7 +18,7 @@ macro_rules! panictry {
             Ok(e) => e,
             Err(mut e) => {
                    e.emit();
-                   panic!(FatalError);
+                   FatalError.raise();
                }
         }
     })


### PR DESCRIPTION
As per https://github.com/rust-lang/rust/commit/9a8d6b8bb5dd7dd2d378849f0c2fa586e3a5b48b;

`FatalError` is made ```!Send``` which in turn makes it impossible to ```panic!()``` passing the object.
The proper way to panic is now constructing the object and calling ```raise()``` on it.

Fixes #28 