### PR TITLE
Fixes for nightly changes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 
 extern crate rustc;
 extern crate rustc_plugin;
-#[macro_use]
 extern crate syntax;
 
 use rustc_plugin::Registry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 extern crate rustc;
 extern crate rustc_plugin;
+#[macro_use]
 extern crate syntax;
 
 use rustc_plugin::Registry;

--- a/src/parser_any_macro.rs
+++ b/src/parser_any_macro.rs
@@ -1,12 +1,12 @@
 // from src/libsyntax/ext/tt/macro_rules.rs
 
-use std::cell::{RefCell, RefMut};
+use std::cell::RefCell;
 use syntax::parse::parser::Parser;
 use syntax::parse::token;
 use syntax::ast;
 use syntax::ptr::P;
 
-use syntax::ext::base::*;
+use syntax::ext::base::MacResult;
 use syntax::util::small_vector::SmallVector;
 
 
@@ -41,7 +41,7 @@ impl<'a> ParserAnyMacro<'a> {
     /// panic!(); } }` doesn't get picked up by .parse_expr(), but it's
     /// allowed to be there.
     fn ensure_complete_parse(&self, allow_semi: bool) {
-        let mut parser: RefMut<Parser> = self.parser.borrow_mut();
+        let mut parser = self.parser.borrow_mut();
         if allow_semi && parser.token == token::Semi {
             parser.bump();
         }


### PR DESCRIPTION
@SkylerLipthay This is a 'fix' for the current build errors on nightly reported in #33, although I do not pretend these are good or even correct fixes. I deliberately didn't try and make the second commit for replacing `parse_impl_item` with `parse_item` be 'nice' as I definitely have no idea what I'm doing and have just poked till it built and my use cases worked. Just putting this up as a "this seems to work for me" example.