### PR TITLE
codemap was renamed to source_map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "interpolate_idents"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Skyler Lipthay <skyler.lipthay@gmail.com>"]
 description = "Useable macro identifier concatenation plugin"
 readme = "README.md"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate syntax;
 use rustc_plugin::Registry;
 use syntax::ast::Ident;
 use syntax::tokenstream::{TokenStream, TokenTree};
-use syntax::codemap::Span;
+use syntax::source_map::Span;
 use syntax::ext::base::{ExtCtxt, MacResult};
 use syntax::parse::token::{DelimToken, Token};
 


### PR DESCRIPTION
This makes interpolate_idents compile with the latest nightly.